### PR TITLE
docs: fix simple typo, avaiable -> available

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Adds the specified directories to the Python path for the currently-active virtu
 
 Sometimes it is desirable to share installed packages that are not in the system `site-packages` directory and which should not be installed in each virtualenv. One possible solution is to symlink the source into the environment `site-packages` directory, but it is also easy to add extra directories to the PYTHONPATH by including them in a `.pth` file inside `site-packages` using `pew add`.
 
-The `-d` flag removes previously added directiories.
+The `-d` flag removes previously added directories.
 
 The directory names are added to a path file named `_virtualenv_path_extensions.pth` inside the site-packages directory for the environment.
 

--- a/pew/pew.py
+++ b/pew/pew.py
@@ -20,7 +20,7 @@ windows = sys.platform == 'win32'
 from clonevirtualenv import clone_virtualenv
 if not windows:
     try:
-        # Try importing these packages if avaiable
+        # Try importing these packages if available
         from pythonz.commands.install import InstallCommand
         from pythonz.commands.uninstall import UninstallCommand
         from pythonz.installer.pythoninstaller import PythonInstaller, AlreadyInstalledError


### PR DESCRIPTION
There is a small typo in pew/pew.py.

Should read `available` rather than `avaiable`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md